### PR TITLE
version 1.0.0 -> 1.1.1

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=BlueRobotics Keller LD Library
-version=1.0.0
+version=1.1.1
 author=BlueRobotics
 maintainer=BlueRobotics <info@bluerobotics.com>
 sentence=A simple and easy library for the Keller LD series pressure/depth sensors


### PR DESCRIPTION
For the library to be updated in the Arduino Library Manager it needs to have a new version specified in `library.properties`, and a new release with that same version.

This library only has a single release at the moment, so the release notes for 1.1.1 should include:
- Get more details from sensor meta data
- Handle pressure offset for different sensor types (PR/PA/PAA)