### PR TITLE
Removes local declaration of P_mode from within ::init.

### DIFF
--- a/KellerLD.cpp
+++ b/KellerLD.cpp
@@ -34,7 +34,7 @@ void KellerLD::init() {
 	day = (scaling0 & 0b0000000001111100) >> 2;
 	
 	// handle P-mode pressure offset (to vacuum pressure)
-	float P_mode;
+
 	if (mode == 0) { 
 		// PA mode, Vented Gauge. Zero at atmospheric pressure
 		P_mode = 1.01325;


### PR DESCRIPTION
This was preventing the subsequent code from writing the correct value of P_mode into the member variable P_mode. Consequently all sensors were being treated as PAA (absolute) rather than getting the correct offset correction.