### PR TITLE
Choose I²C Address

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+.pio
+.idea
+CMake*
+CMakeListsPrivate.txt
+cmake-build-*/ 

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,2 @@
 .pio
 .idea
-CMake*
-CMakeListsPrivate.txt
-cmake-build-*/ 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,23 @@
 # BlueRobotics_KellerLD_Library
 
-Arduino library for the Keller 4LD - 9LD I2C pressure and temperature sensors; used in the Bar100 Sensor from Blue Robotics.
+Arduino library for the Keller 4LD to 9LD I²C pressure and temperature sensors;
+used in the Bar100 Sensor from Blue Robotics.
 
-See the [Keller Communication Protocol 4LD-9LD](http://www.keller-druck2.ch/swupdate/InstallerD-LineAddressManager/manual/Communication_Protocol_4LD-9LD_en.pdf) document for more details on the I<sup>2</sup>C communication protocol, and the [Keller 4LD-9LD Datasheet](https://download.keller-druck.com/api/download/2LfcGMzMbeHdjFbyUd5DWA/en/latest) for sensor specification details.
+See the [Keller Communication Protocol 4LD-9LD][com] document for more details
+on the I²C communication protocol, and the [Keller 4LD-9LD
+Datasheet][datasheet] for sensor specification details.
+
+[com]: http://www.keller-druck2.ch/swupdate/InstallerD-LineAddressManager/manual/Communication_Protocol_4LD-9LD_en.pdf
+[datasheet]: https://download.keller-druck.com/api/download/2LfcGMzMbeHdjFbyUd5DWA/en/latest
+
+## Changelog
+
+* `2.0.0`
+  * Allow user-defined I²C address for the sensor
+  * Calibration date fields renamed to `calibration{Year,Month,Day}`
+* `1.1.0` (2021-07-01)
+  * Add P-mode pressure offset handling for PR, PA and PAA type sensors,
+    auto-determined based on sensor mode
+  * Add support to read out the calibration date
+* `1.0.0` (2017-08-31)
+  * Initial release.

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Datasheet][datasheet] for sensor specification details.
 * `2.0.0`
   * Allow user-defined I²C address for the sensor
   * Calibration date fields renamed to `calibration{Year,Month,Day}`
-* `1.1.0` (2021-07-01)
+* `1.1.1` (2021-07-01)
   * Add P-mode pressure offset handling for PR, PA and PAA type sensors,
     auto-determined based on sensor mode
   * Add support to read out the calibration date

--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ Datasheet][datasheet] for sensor specification details.
 * `2.0.0`
   * Allow user-defined I²C address for the sensor
   * Calibration date fields renamed to `calibration{Year,Month,Day}`
+* `1.1.2` (2022-02-16)
+  * Fix pressure calculation; all sensors were treated as PAA
 * `1.1.1` (2021-07-01)
   * Add P-mode pressure offset handling for PR, PA and PAA type sensors,
     auto-determined based on sensor mode

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=BlueRobotics Keller LD Library
-version=1.1.2
+version=2.0.0
 author=BlueRobotics
 maintainer=BlueRobotics <info@bluerobotics.com>
 sentence=A simple and easy library for the Keller LD series pressure/depth sensors

--- a/platformio.ini
+++ b/platformio.ini
@@ -1,0 +1,15 @@
+; PlatformIO Project Configuration File
+;
+;   Build options: build flags, source filter
+;   Upload options: custom upload port, speed and extra flags
+;   Library options: dependencies, extra library storages
+;   Advanced options: extra scripting
+;
+; Please visit documentation for the other options and examples
+; https://docs.platformio.org/page/projectconf.html
+
+
+[env:promini]
+platform = atmelavr
+board = pro8MHzatmega328
+framework = arduino

--- a/src/KellerLD.cpp
+++ b/src/KellerLD.cpp
@@ -32,7 +32,7 @@ void KellerLD::init() {
 	year = scaling0 >> 11;
 	month = (scaling0 & 0b0000011110000000) >> 7;
 	day = (scaling0 & 0b0000000001111100) >> 2;
-	
+
 	// handle P-mode pressure offset (to vacuum pressure)
 
 	if (mode == 0) { 
@@ -51,11 +51,11 @@ void KellerLD::init() {
 
 	uint32_t scaling12 = (uint32_t(readMemoryMap(LD_SCALING1)) << 16) | readMemoryMap(LD_SCALING2);
 
-	P_min = *reinterpret_cast<float*>(&scaling12);
+	P_min = *reinterpret_cast<float *>(&scaling12);
 
 	uint32_t scaling34 = (uint32_t(readMemoryMap(LD_SCALING3)) << 16) | readMemoryMap(LD_SCALING4);
 
-	P_max = *reinterpret_cast<float*>(&scaling34);
+	P_max = *reinterpret_cast<float *>(&scaling34);
 }
 
 void KellerLD::setFluidDensity(float density) {
@@ -71,13 +71,13 @@ void KellerLD::read() {
 
 	delay(9); // Max conversion time per datasheet
 
- 	Wire.requestFrom(LD_ADDR,5);
+	Wire.requestFrom(LD_ADDR, 5);
 	status = Wire.read();
 	P = (Wire.read() << 8) | Wire.read();
 	uint16_t T = (Wire.read() << 8) | Wire.read();
-	
-	P_bar = (float(P)-16384)*(P_max-P_min)/32768 + P_min + P_mode;
-	T_degc = ((T>>4)-24)*0.05-50;
+
+	P_bar = (float(P) - 16384) * (P_max - P_min) / 32768 + P_min + P_mode;
+	T_degc = ((T >> 4) - 24) * 0.05 - 50;
 }
 
 uint16_t KellerLD::readMemoryMap(uint8_t mtp_address) {
@@ -89,13 +89,13 @@ uint16_t KellerLD::readMemoryMap(uint8_t mtp_address) {
 
 	delay(1); // allow for response to come in
 
-	Wire.requestFrom(LD_ADDR,3);
+	Wire.requestFrom(LD_ADDR, 3);
 	status = Wire.read();
 	return ((Wire.read() << 8) | Wire.read());
 }
 
 bool KellerLD::status() {
-	if (equipment <= 62 ) {
+	if (equipment <= 62) {
 		return true;
 	} else {
 		return false;
@@ -103,11 +103,11 @@ bool KellerLD::status() {
 }
 
 float KellerLD::range() {
-	return P_max-P_min;
+	return P_max - P_min;
 }
 
 float KellerLD::pressure(float conversion) {
-	return P_bar*1000.0f*conversion;
+	return P_bar * 1000.0f * conversion;
 }
 
 float KellerLD::temperature() {
@@ -115,11 +115,11 @@ float KellerLD::temperature() {
 }
 
 float KellerLD::depth() {
-	return (pressure(KellerLD::Pa)-101325)/(fluidDensity*9.80665);
+	return (pressure(KellerLD::Pa) - 101325) / (fluidDensity * 9.80665);
 }
 
 float KellerLD::altitude() {
-	return (1-pow((pressure()/1013.25),0.190284))*145366.45*.3048;
+	return (1 - pow((pressure() / 1013.25), 0.190284)) * 145366.45 * .3048;
 }
 
 bool KellerLD::isInitialized() {

--- a/src/KellerLD.cpp
+++ b/src/KellerLD.cpp
@@ -12,11 +12,7 @@
 #define LD_SCALING4                 0x16
 
 
-KellerLD::KellerLD()
-		: i2cAddress(LD_DEFAULT_ADDR) {
-}
-
-KellerLD::KellerLD(int i2cAddress)
+KellerLD::KellerLD(int i2cAddress = LD_DEFAULT_ADDR)
 		: i2cAddress(i2cAddress) {
 }
 

--- a/src/KellerLD.h
+++ b/src/KellerLD.h
@@ -110,6 +110,8 @@ private:
 	uint16_t cust_id1;
 
 	uint16_t readMemoryMap(uint8_t mtp_address);
+
+    const int i2cAddress;
 };
 
 #endif

--- a/src/KellerLD.h
+++ b/src/KellerLD.h
@@ -61,7 +61,7 @@ public:
 	 */
 	void read();
 
-	/** Checks if the attached sensor is connectored or not. */
+	/** Checks if the attached sensor is connected or not. */
 	bool status();
 
 	/** Returns current range of the attached sensor. */

--- a/src/KellerLD.h
+++ b/src/KellerLD.h
@@ -45,6 +45,8 @@ public:
 
 	KellerLD();
 
+	explicit KellerLD(int i2cAddress);
+
   /** Reads the onboard memory map to determine min and max pressure as 
    *  well as manufacture date, mode, and customer ID.
    */
@@ -90,9 +92,9 @@ public:
 	uint16_t file;
 
 	uint8_t mode;
-	uint16_t year;
-	uint8_t month;
-	uint8_t day;
+	uint16_t calibrationYear;
+	uint8_t calibrationMonth;
+	uint8_t calibrationDay;
 
 	uint32_t code;
 
@@ -103,7 +105,7 @@ public:
 	float P_max;
 
 private:
-	float fluidDensity;
+	float fluidDensity = 1029;
 	float T_degc;
 
 	uint16_t cust_id0;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,7 +1,7 @@
 #include "Arduino.h"
 #include "KellerLD.h"
 
-KellerLD sensor;
+KellerLD sensor(0x61);
 
 void setup() {
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,0 +1,10 @@
+#include "Arduino.h"
+#include "KellerLD.h"
+
+KellerLD sensor;
+
+void setup() {
+}
+
+void loop() {
+}


### PR DESCRIPTION
The LD pressure sensors have a configurable I²C address. This MR allows to use the sensors even if they use a different address, and thus would also allow to interface with multiple sensors on the same I²C bus.

Additionally, it adds a PlatformIO file which is helpful for development as the project can easily be opened with CLion, VS Code, etc.