### PR TITLE
KellerLD: validate status byte in read() and report sample validity

### DIFF
--- a/KellerLD.cpp
+++ b/KellerLD.cpp
@@ -62,7 +62,7 @@ void KellerLD::setFluidDensity(float density) {
 	fluidDensity = density;
 }
 
-void KellerLD::read() {
+bool KellerLD::read() {
 	uint8_t status;
 
 	Wire.beginTransmission(LD_ADDR);
@@ -73,11 +73,23 @@ void KellerLD::read() {
 
  	Wire.requestFrom(LD_ADDR,5);
 	status = Wire.read();
-	P = (Wire.read() << 8) | Wire.read();
+	uint16_t P_raw = (Wire.read() << 8) | Wire.read();
 	uint16_t T = (Wire.read() << 8) | Wire.read();
-	
+
+	// Validate the status byte (0b01BMoEXX) before trusting the data:
+	//   bit 7    reserved, must be 0
+	//   bit 6    reserved, must be 1
+	//   bits 4-3 operating mode, must be 00 (normal measurement)
+	//   bit 2    memory/EEPROM checksum error, must be 0
+	// BUSY (bit 5) and the don't-care bits (1-0) are masked out.
+	if ((status & 0b11011100) != 0b01000000) {
+		return false;
+	}
+
+	P = P_raw;
 	P_bar = (float(P)-16384)*(P_max-P_min)/32768 + P_min + P_mode;
 	T_degc = ((T>>4)-24)*0.05-50;
+	return true;
 }
 
 uint16_t KellerLD::readMemoryMap(uint8_t mtp_address) {

--- a/KellerLD.h
+++ b/KellerLD.h
@@ -55,9 +55,14 @@ public:
 	 */
 	void setFluidDensity(float density);
 
-	/** The read from I2C takes up for 40 ms, so use sparingly is possible.
+	/** Reads a pressure/temperature measurement from the sensor.
+	 *
+	 * The read from I2C takes up to 40 ms, so use sparingly if possible.
+	 *
+	 * Returns false if the sample's status is flagged as invalid, else
+	 * updates the stored pressure/temperature values and returns true.
 	 */
-	void read();
+	bool read();
 
 	/** Checks if the attached sensor is connectored or not. */
 	bool status();


### PR DESCRIPTION
`read()` requests the 5-byte measurement block and reads the leading status byte into a local variable, but then discards it — every read is treated as valid and written into `P_bar`/`T_degc`, including frames where the sensor reports it is not returning a normal measurement (e.g. `0x00` post-reset/not-ready, `0xFF` bus-stuck-high, command mode, or a memory-checksum error).

This validates the status byte (`0b01BMoEXX`) with a single mask, `(status & 0b11011100) != 0b01000000`, rejecting any frame whose reserved bits (7=0, 6=1), operating-mode bits (4–3=00), or memory-checksum bit (2) indicate an invalid sample. BUSY (bit 5) is intentionally left unchecked, matching the BlueRobotics Python reference driver and the equivalent fix merged into ArduPilot's Keller driver ([ArduPilot/ardupilot#32889](https://github.com/ArduPilot/ardupilot/pull/32889)).

`read()` now returns `bool` (true = valid measurement). On a rejected sample the previously stored pressure/temperature are left unchanged and it returns `false`. This is source-compatible: existing sketches that call `sensor.read();` and ignore the result continue to compile and behave as before, except that glitched samples no longer overwrite good data. Verified the bundled example still compiles (arduino-cli, esp32 core).

Companion to the parity fix in [bluerobotics/KellerLD-python#16](https://github.com/bluerobotics/KellerLD-python/pull/16).

Made with [Cursor](https://cursor.com)